### PR TITLE
fix: remove obsolete <bit> #include

### DIFF
--- a/base/numerics/byte_conversions.h
+++ b/base/numerics/byte_conversions.h
@@ -6,7 +6,6 @@
 #define MINI_CHROMIUM_BASE_NUMERICS_BYTE_CONVERSIONS_H_
 
 #include <array>
-#include <bit>
 #include <cstdint>
 #include <cstring>
 #include <type_traits>


### PR DESCRIPTION
For some reason, this `#include` still survived the initial C++17 changes. `<bit>` is a C++20 header and should not be included in our C++17 fork (and also is not necessary to compile or run).