### PR TITLE
feat: file logging and configurable minimum log level

### DIFF
--- a/base/files/file_util.cc
+++ b/base/files/file_util.cc
@@ -1,0 +1,21 @@
+// Copyright 2006-2008 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/files/file_util.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "base/strings/utf_string_conversions.h"
+#endif
+
+namespace base {
+
+FILE* OpenFile(const FilePath& filename, const char* mode) {
+#if BUILDFLAG(IS_WIN)
+  return _wfopen(filename.value().c_str(), UTF8ToWide(mode).c_str());
+#else
+  return fopen(filename.value().c_str(), mode);
+#endif
+}
+
+}  // namespace base

--- a/base/files/file_util.h
+++ b/base/files/file_util.h
@@ -5,7 +5,17 @@
 #ifndef MINI_CHROMIUM_BASE_FILES_FILE_UTIL_H_
 #define MINI_CHROMIUM_BASE_FILES_FILE_UTIL_H_
 
+#include <stdio.h>
+
+#include "base/files/file_path.h"
 #include "build/build_config.h"
+
+namespace base {
+
+// Wrapper for fopen-like calls. Returns non-NULL FILE* on success.
+FILE* OpenFile(const FilePath& filename, const char* mode);
+
+}  // namespace base
 
 #if BUILDFLAG(IS_POSIX)
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -40,6 +40,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/synchronization/lock.h"
 
 namespace logging {
 
@@ -61,9 +62,11 @@ int g_min_log_level = LOG_INFO;
 
 // Held across the program lifetime when LOG_TO_FILE is enabled. The file is
 // opened lazily on the first emitted message; the ScopedFILE destructor
-// closes it at program exit.
+// closes it at program exit. g_log_file_lock guards lazy open and writes so
+// concurrent LOG calls don't race.
 base::FilePath::StringType g_log_file_path;
 base::ScopedFILE g_log_file;
+base::Lock g_log_file_lock;
 
 }  // namespace
 
@@ -82,8 +85,11 @@ bool InitLogging(const LoggingSettings& settings) {
 
   // Close any previously opened file; the new path is opened lazily on the
   // first emitted message.
-  g_log_file.reset();
-  g_log_file_path = settings.log_file_path;
+  {
+    base::AutoLock lock(g_log_file_lock);
+    g_log_file.reset();
+    g_log_file_path = settings.log_file_path;
+  }
   g_logging_destination = settings.logging_dest;
   g_min_log_level = settings.min_log_level;
   return true;
@@ -170,6 +176,7 @@ void LogMessage::Flush() {
   }
 
   if ((g_logging_destination & LOG_TO_FILE)) {
+    base::AutoLock lock(g_log_file_lock);
     if (!g_log_file) {
       g_log_file.reset(
           base::OpenFile(base::FilePath(g_log_file_path), "a"));

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -77,7 +77,7 @@ bool InitLogging(const LoggingSettings& settings) {
   base::ScopedFILE log_file;
   if (settings.logging_dest & LOG_TO_FILE) {
     log_file.reset(
-        base::OpenFile(base::FilePath(settings.log_file_path), "w"));
+        base::OpenFile(base::FilePath(settings.log_file_path), "a"));
     if (!log_file) {
       return false;
     }

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -64,14 +64,16 @@ base::ScopedFILE g_log_file;
 }  // namespace
 
 bool InitLogging(const LoggingSettings& settings) {
+  base::ScopedFILE log_file;
   if (settings.logging_dest & LOG_TO_FILE) {
-    g_log_file.reset(
+    log_file.reset(
         base::OpenFile(base::FilePath(settings.log_file_path), "w"));
-    if (!g_log_file) {
+    if (!log_file) {
       return false;
     }
   }
 
+  g_log_file = std::move(log_file);
   g_logging_destination = settings.logging_dest;
   return true;
 }

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -64,8 +64,6 @@ base::ScopedFILE g_log_file;
 }  // namespace
 
 bool InitLogging(const LoggingSettings& settings) {
-  g_logging_destination = settings.logging_dest;
-
   if ((settings.logging_dest & LOG_TO_FILE) && !settings.log_file_path.empty()) {
     g_log_file.reset(
         base::OpenFile(base::FilePath(settings.log_file_path), "w"));
@@ -74,6 +72,7 @@ bool InitLogging(const LoggingSettings& settings) {
     }
   }
 
+  g_logging_destination = settings.logging_dest;
   return true;
 }
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -64,7 +64,7 @@ base::ScopedFILE g_log_file;
 }  // namespace
 
 bool InitLogging(const LoggingSettings& settings) {
-  if ((settings.logging_dest & LOG_TO_FILE) && !settings.log_file_path.empty()) {
+  if (settings.logging_dest & LOG_TO_FILE) {
     g_log_file.reset(
         base::OpenFile(base::FilePath(settings.log_file_path), "w"));
     if (!g_log_file) {

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -63,10 +63,12 @@ int g_min_log_level = LOG_INFO;
 // Held across the program lifetime when LOG_TO_FILE is enabled. The file is
 // opened lazily on the first emitted message; the ScopedFILE destructor
 // closes it at program exit. g_log_file_lock guards lazy open and writes so
-// concurrent LOG calls don't race.
+// concurrent LOG calls don't race, and is declared first so it outlives
+// g_log_file during static destruction -- ScopedFILECloser may PLOG on
+// fclose failure, which re-enters Flush() and needs the lock.
+base::Lock g_log_file_lock;
 base::FilePath::StringType g_log_file_path;
 base::ScopedFILE g_log_file;
-base::Lock g_log_file_lock;
 
 }  // namespace
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -59,8 +59,10 @@ LoggingDestination g_logging_destination = LOG_DEFAULT;
 
 int g_min_log_level = LOG_INFO;
 
-// Held across the program lifetime when LOG_TO_FILE is enabled. Closed by its
-// destructor at program exit.
+// Held across the program lifetime when LOG_TO_FILE is enabled. The file is
+// opened lazily on the first emitted message; the ScopedFILE destructor
+// closes it at program exit.
+base::FilePath::StringType g_log_file_path;
 base::ScopedFILE g_log_file;
 
 }  // namespace
@@ -74,16 +76,14 @@ void SetMinLogLevel(int level) {
 }
 
 bool InitLogging(const LoggingSettings& settings) {
-  base::ScopedFILE log_file;
-  if (settings.logging_dest & LOG_TO_FILE) {
-    log_file.reset(
-        base::OpenFile(base::FilePath(settings.log_file_path), "a"));
-    if (!log_file) {
-      return false;
-    }
+  if ((settings.logging_dest & LOG_TO_FILE) && settings.log_file_path.empty()) {
+    return false;
   }
 
-  g_log_file = std::move(log_file);
+  // Close any previously opened file; the new path is opened lazily on the
+  // first emitted message.
+  g_log_file.reset();
+  g_log_file_path = settings.log_file_path;
   g_logging_destination = settings.logging_dest;
   g_min_log_level = settings.min_log_level;
   return true;
@@ -170,6 +170,10 @@ void LogMessage::Flush() {
   }
 
   if ((g_logging_destination & LOG_TO_FILE)) {
+    if (!g_log_file) {
+      g_log_file.reset(
+          base::OpenFile(base::FilePath(g_log_file_path), "a"));
+    }
     if (FILE* f = g_log_file.get()) {
       fwrite(str_newline.data(), 1, str_newline.size(), f);
       fflush(f);

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -34,6 +34,8 @@
 #endif
 
 #include "base/check_op.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_file.h"
 #include "base/immediate_crash.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
@@ -55,12 +57,23 @@ LogMessageHandlerFunction g_log_message_handler = nullptr;
 
 LoggingDestination g_logging_destination = LOG_DEFAULT;
 
+// Held across the program lifetime when LOG_TO_FILE is enabled. Closed by its
+// destructor at program exit.
+base::ScopedFILE g_log_file;
+
 }  // namespace
 
 bool InitLogging(const LoggingSettings& settings) {
-  DCHECK_EQ(settings.logging_dest & LOG_TO_FILE, 0u);
-
   g_logging_destination = settings.logging_dest;
+
+  if ((settings.logging_dest & LOG_TO_FILE) && !settings.log_file_path.empty()) {
+    g_log_file.reset(
+        base::OpenFile(base::FilePath(settings.log_file_path), "w"));
+    if (!g_log_file) {
+      return false;
+    }
+  }
+
   return true;
 }
 
@@ -142,6 +155,13 @@ void LogMessage::Flush() {
   if ((g_logging_destination & LOG_TO_STDERR)) {
     fprintf(stderr, "%s", str_newline.c_str());
     fflush(stderr);
+  }
+
+  if ((g_logging_destination & LOG_TO_FILE)) {
+    if (FILE* f = g_log_file.get()) {
+      fwrite(str_newline.data(), 1, str_newline.size(), f);
+      fflush(f);
+    }
   }
 
   if ((g_logging_destination & LOG_TO_SYSTEM_DEBUG_LOG) != 0) {

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -57,11 +57,21 @@ LogMessageHandlerFunction g_log_message_handler = nullptr;
 
 LoggingDestination g_logging_destination = LOG_DEFAULT;
 
+int g_min_log_level = LOG_INFO;
+
 // Held across the program lifetime when LOG_TO_FILE is enabled. Closed by its
 // destructor at program exit.
 base::ScopedFILE g_log_file;
 
 }  // namespace
+
+int GetMinLogLevel() {
+  return g_min_log_level;
+}
+
+void SetMinLogLevel(int level) {
+  g_min_log_level = level;
+}
 
 bool InitLogging(const LoggingSettings& settings) {
   base::ScopedFILE log_file;
@@ -75,6 +85,7 @@ bool InitLogging(const LoggingSettings& settings) {
 
   g_log_file = std::move(log_file);
   g_logging_destination = settings.logging_dest;
+  g_min_log_level = settings.min_log_level;
   return true;
 }
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -86,10 +86,13 @@ bool InitLogging(const LoggingSettings& settings) {
   }
 
   // Close any previously opened file; the new path is opened lazily on the
-  // first emitted message.
+  // first emitted message. The old file is moved out of the critical section
+  // so its destructor (and any PLOG from a failing fclose) runs after the
+  // lock is released, avoiding a re-entrant acquire.
+  base::ScopedFILE old_log_file;
   {
     base::AutoLock lock(g_log_file_lock);
-    g_log_file.reset();
+    old_log_file = std::move(g_log_file);
     g_log_file_path = settings.log_file_path;
   }
   g_logging_destination = settings.logging_dest;

--- a/base/logging.h
+++ b/base/logging.h
@@ -41,18 +41,6 @@ enum : LoggingDestination {
 #endif
 };
 
-struct LoggingSettings {
-  LoggingDestination logging_dest = LOG_DEFAULT;
-
-  // The log file path, used when logging_dest includes LOG_TO_FILE. The file
-  // is opened for writing (truncating any existing content) during
-  // InitLogging().
-  base::FilePath::StringType log_file_path;
-};
-
-// Sets the logging destination.
-bool InitLogging(const LoggingSettings& settings);
-
 typedef int LogSeverity;
 const LogSeverity LOG_VERBOSE = -1;
 const LogSeverity LOG_INFO = 0;
@@ -61,6 +49,22 @@ const LogSeverity LOG_ERROR = 2;
 const LogSeverity LOG_ERROR_REPORT = 3;
 const LogSeverity LOG_FATAL = 4;
 const LogSeverity LOG_NUM_SEVERITIES = 5;
+
+struct LoggingSettings {
+  LoggingDestination logging_dest = LOG_DEFAULT;
+
+  // The log file path, used when logging_dest includes LOG_TO_FILE. The file
+  // is opened for writing (truncating any existing content) during
+  // InitLogging().
+  base::FilePath::StringType log_file_path;
+
+  // Minimum severity that will be emitted. Defaults to LOG_INFO so every
+  // non-verbose message passes through.
+  int min_log_level = LOG_INFO;
+};
+
+// Sets the logging destination.
+bool InitLogging(const LoggingSettings& settings);
 
 #if defined(NDEBUG)
 const LogSeverity LOG_DFATAL = LOG_ERROR;
@@ -77,9 +81,8 @@ typedef bool (*LogMessageHandlerFunction)(LogSeverity severity,
 void SetLogMessageHandler(LogMessageHandlerFunction log_message_handler);
 LogMessageHandlerFunction GetLogMessageHandler();
 
-static inline int GetMinLogLevel() {
-  return LOG_INFO;
-}
+int GetMinLogLevel();
+void SetMinLogLevel(int level);
 
 static inline int GetVlogLevel(const char*) {
   return std::numeric_limits<int>::max();

--- a/base/logging.h
+++ b/base/logging.h
@@ -83,8 +83,11 @@ LogMessageHandlerFunction GetLogMessageHandler();
 int GetMinLogLevel();
 void SetMinLogLevel(int level);
 
+// VLOG(N) fires when the current minimum severity is low enough to admit a
+// LogMessage of severity -N. This mirrors LOG_IS_ON's severity check rather
+// than implementing Chromium's per-file --v flag.
 static inline int GetVlogLevel(const char*) {
-  return std::numeric_limits<int>::max();
+  return -GetMinLogLevel();
 }
 
 #if BUILDFLAG(IS_WIN)

--- a/base/logging.h
+++ b/base/logging.h
@@ -54,7 +54,7 @@ struct LoggingSettings {
   LoggingDestination logging_dest = LOG_DEFAULT;
 
   // The log file path, used when logging_dest includes LOG_TO_FILE. The file
-  // is opened for appending during InitLogging().
+  // is opened lazily for appending on the first emitted message.
   base::FilePath::StringType log_file_path;
 
   // Minimum severity that will be emitted. Defaults to LOG_INFO so every

--- a/base/logging.h
+++ b/base/logging.h
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 
+#include "base/files/file_path.h"
 #include "build/build_config.h"
 
 namespace logging {
@@ -42,11 +43,14 @@ enum : LoggingDestination {
 
 struct LoggingSettings {
   LoggingDestination logging_dest = LOG_DEFAULT;
+
+  // The log file path, used when logging_dest includes LOG_TO_FILE. The file
+  // is opened for writing (truncating any existing content) during
+  // InitLogging().
+  base::FilePath::StringType log_file_path;
 };
 
 // Sets the logging destination.
-//
-// TODO(jperaza): LOG_TO_FILE is not yet supported.
 bool InitLogging(const LoggingSettings& settings);
 
 typedef int LogSeverity;

--- a/base/logging.h
+++ b/base/logging.h
@@ -83,11 +83,8 @@ LogMessageHandlerFunction GetLogMessageHandler();
 int GetMinLogLevel();
 void SetMinLogLevel(int level);
 
-// VLOG(N) fires when the current minimum severity is low enough to admit a
-// LogMessage of severity -N. This mirrors LOG_IS_ON's severity check rather
-// than implementing Chromium's per-file --v flag.
 static inline int GetVlogLevel(const char*) {
-  return -GetMinLogLevel();
+  return std::numeric_limits<int>::max();
 }
 
 #if BUILDFLAG(IS_WIN)

--- a/base/logging.h
+++ b/base/logging.h
@@ -54,8 +54,7 @@ struct LoggingSettings {
   LoggingDestination logging_dest = LOG_DEFAULT;
 
   // The log file path, used when logging_dest includes LOG_TO_FILE. The file
-  // is opened for writing (truncating any existing content) during
-  // InitLogging().
+  // is opened for appending during InitLogging().
   base::FilePath::StringType log_file_path;
 
   // Minimum severity that will be emitted. Defaults to LOG_INFO so every


### PR DESCRIPTION
Required for:
- https://github.com/getsentry/crashpad/pull/148
- https://github.com/getsentry/sentry-native/pull/1658

Two additions to mini_chromium's logging:

1. **`LOG_TO_FILE` destination.** Implements the previously stubbed `LOG_TO_FILE` destination and adds a simplified `base::OpenFile()` helper (after upstream Chromium's helper of the same name). Callers pass the path via `LoggingSettings::log_file_path`; the file is held open for the program's lifetime and closed by the destructor of a file-scope `base::ScopedFILE` at exit.

2. **Configurable minimum log level.** Replaces the hardcoded `GetMinLogLevel()` with a runtime-configurable value. Adds `SetMinLogLevel()` and a `min_log_level` field on `LoggingSettings` (applied by `InitLogging`). Default remains `LOG_INFO`, so existing callers are unaffected.

See also:
- https://github.com/getsentry/sentry-native/issues/1468