### PR TITLE
feat: file logging and configurable minimum log level

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -22,6 +22,7 @@ static_library("base") {
     "debug/alias.h",
     "files/file_path.cc",
     "files/file_path.h",
+    "files/file_util.cc",
     "files/file_util.h",
     "files/scoped_file.cc",
     "files/scoped_file.h",

--- a/base/files/file_util.cc
+++ b/base/files/file_util.cc
@@ -1,0 +1,21 @@
+// Copyright 2006-2008 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/files/file_util.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "base/strings/utf_string_conversions.h"
+#endif
+
+namespace base {
+
+FILE* OpenFile(const FilePath& filename, const char* mode) {
+#if BUILDFLAG(IS_WIN)
+  return _wfopen(filename.value().c_str(), UTF8ToWide(mode).c_str());
+#else
+  return fopen(filename.value().c_str(), mode);
+#endif
+}
+
+}  // namespace base

--- a/base/files/file_util.h
+++ b/base/files/file_util.h
@@ -5,7 +5,17 @@
 #ifndef MINI_CHROMIUM_BASE_FILES_FILE_UTIL_H_
 #define MINI_CHROMIUM_BASE_FILES_FILE_UTIL_H_
 
+#include <stdio.h>
+
+#include "base/files/file_path.h"
 #include "build/build_config.h"
+
+namespace base {
+
+// Wrapper for fopen-like calls. Returns non-NULL FILE* on success.
+FILE* OpenFile(const FilePath& filename, const char* mode);
+
+}  // namespace base
 
 #if BUILDFLAG(IS_POSIX)
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -78,7 +78,7 @@ struct LogFileCloser {
 // the open fails or the path is empty, and reset by InitLogging.
 struct LogFile {
   base::Lock lock;
-  base::FilePath::StringType path;
+  base::FilePath path;
   std::unique_ptr<FILE, LogFileCloser> handle;
   bool enabled = true;
 };
@@ -199,8 +199,7 @@ void LogMessage::Flush() {
       if (g_log_file.path.empty()) {
         g_log_file.enabled = false;
       } else {
-        g_log_file.handle.reset(
-            base::OpenFile(base::FilePath(g_log_file.path), "a"));
+        g_log_file.handle.reset(base::OpenFile(g_log_file.path, "a"));
         if (!g_log_file.handle) {
           g_log_file.enabled = false;
         }

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -7,7 +7,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <atomic>
 #include <iomanip>
+#include <memory>
 #include <ostream>
 
 #if BUILDFLAG(IS_POSIX)
@@ -34,10 +36,12 @@
 #endif
 
 #include "base/check_op.h"
+#include "base/files/file_util.h"
 #include "base/immediate_crash.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/synchronization/lock.h"
 
 namespace logging {
 
@@ -53,14 +57,56 @@ const char* const log_severity_names[] = {
 
 LogMessageHandlerFunction g_log_message_handler = nullptr;
 
-LoggingDestination g_logging_destination = LOG_DEFAULT;
+std::atomic<LoggingDestination> g_logging_destination{LOG_DEFAULT};
+
+std::atomic<int> g_min_log_level{LOG_INFO};
+
+// Closes a log file silently on destruction. Unlike base::ScopedFILECloser,
+// LogFileCloser does not PLOG on fclose failure. We may be inside static
+// destruction where a re-entrant Flush() would access the log file while it
+// is being torn down.
+struct LogFileCloser {
+  void operator()(FILE* file) const {
+    if (file) {
+      fclose(file);
+    }
+  }
+};
+
+// File-bound logging state. All fields are protected by `lock`. The handle
+// is opened lazily on the first emitted message; `enabled` is cleared when
+// the open fails or the path is empty, and reset by InitLogging.
+struct LogFile {
+  base::Lock lock;
+  base::FilePath::StringType path;
+  std::unique_ptr<FILE, LogFileCloser> handle;
+  bool enabled = true;
+};
+LogFile g_log_file;
 
 }  // namespace
 
-bool InitLogging(const LoggingSettings& settings) {
-  DCHECK_EQ(settings.logging_dest & LOG_TO_FILE, 0u);
+int GetMinLogLevel() {
+  return g_min_log_level.load(std::memory_order_relaxed);
+}
 
-  g_logging_destination = settings.logging_dest;
+void SetMinLogLevel(int level) {
+  g_min_log_level.store(level, std::memory_order_relaxed);
+}
+
+bool InitLogging(const LoggingSettings& settings) {
+  // Close any previously opened file; the new path is opened lazily on the
+  // first emitted message. The old handle is moved out of the critical
+  // section so its destructor runs after the lock is released.
+  std::unique_ptr<FILE, LogFileCloser> old_handle;
+  {
+    base::AutoLock lock(g_log_file.lock);
+    old_handle = std::move(g_log_file.handle);
+    g_log_file.path = settings.log_file_path;
+    g_log_file.enabled = true;
+  }
+  g_logging_destination.store(settings.logging_dest, std::memory_order_relaxed);
+  g_min_log_level.store(settings.min_log_level, std::memory_order_relaxed);
   return true;
 }
 
@@ -139,12 +185,34 @@ void LogMessage::Flush() {
     return;
   }
 
-  if ((g_logging_destination & LOG_TO_STDERR)) {
+  const LoggingDestination destination =
+      g_logging_destination.load(std::memory_order_relaxed);
+
+  if ((destination & LOG_TO_STDERR)) {
     fprintf(stderr, "%s", str_newline.c_str());
     fflush(stderr);
   }
 
-  if ((g_logging_destination & LOG_TO_SYSTEM_DEBUG_LOG) != 0) {
+  if ((destination & LOG_TO_FILE)) {
+    base::AutoLock lock(g_log_file.lock);
+    if (g_log_file.enabled && !g_log_file.handle) {
+      if (g_log_file.path.empty()) {
+        g_log_file.enabled = false;
+      } else {
+        g_log_file.handle.reset(
+            base::OpenFile(base::FilePath(g_log_file.path), "a"));
+        if (!g_log_file.handle) {
+          g_log_file.enabled = false;
+        }
+      }
+    }
+    if (FILE* f = g_log_file.handle.get()) {
+      fwrite(str_newline.data(), 1, str_newline.size(), f);
+      fflush(f);
+    }
+  }
+
+  if ((destination & LOG_TO_SYSTEM_DEBUG_LOG) != 0) {
 #if BUILDFLAG(IS_APPLE)
     const bool log_to_system = []() {
       struct stat stderr_stat;

--- a/base/logging.h
+++ b/base/logging.h
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 
+#include "base/files/file_path.h"
 #include "build/build_config.h"
 
 namespace logging {
@@ -40,15 +41,6 @@ enum : LoggingDestination {
 #endif
 };
 
-struct LoggingSettings {
-  LoggingDestination logging_dest = LOG_DEFAULT;
-};
-
-// Sets the logging destination.
-//
-// TODO(jperaza): LOG_TO_FILE is not yet supported.
-bool InitLogging(const LoggingSettings& settings);
-
 typedef int LogSeverity;
 const LogSeverity LOG_VERBOSE = -1;
 const LogSeverity LOG_INFO = 0;
@@ -57,6 +49,21 @@ const LogSeverity LOG_ERROR = 2;
 const LogSeverity LOG_ERROR_REPORT = 3;
 const LogSeverity LOG_FATAL = 4;
 const LogSeverity LOG_NUM_SEVERITIES = 5;
+
+struct LoggingSettings {
+  LoggingDestination logging_dest = LOG_DEFAULT;
+
+  // The log file path, used when logging_dest includes LOG_TO_FILE. The file
+  // is opened lazily for appending on the first emitted message.
+  base::FilePath::StringType log_file_path;
+
+  // Minimum severity that will be emitted. Defaults to LOG_INFO so every
+  // non-verbose message passes through.
+  int min_log_level = LOG_INFO;
+};
+
+// Sets the logging destination.
+bool InitLogging(const LoggingSettings& settings);
 
 #if defined(NDEBUG)
 const LogSeverity LOG_DFATAL = LOG_ERROR;
@@ -73,9 +80,8 @@ typedef bool (*LogMessageHandlerFunction)(LogSeverity severity,
 void SetLogMessageHandler(LogMessageHandlerFunction log_message_handler);
 LogMessageHandlerFunction GetLogMessageHandler();
 
-static inline int GetMinLogLevel() {
-  return LOG_INFO;
-}
+int GetMinLogLevel();
+void SetMinLogLevel(int level);
 
 static inline int GetVlogLevel(const char*) {
   return std::numeric_limits<int>::max();

--- a/base/logging.h
+++ b/base/logging.h
@@ -55,7 +55,7 @@ struct LoggingSettings {
 
   // The log file path, used when logging_dest includes LOG_TO_FILE. The file
   // is opened lazily for appending on the first emitted message.
-  base::FilePath::StringType log_file_path;
+  base::FilePath log_file_path;
 
   // Minimum severity that will be emitted. Defaults to LOG_INFO so every
   // non-verbose message passes through.


### PR DESCRIPTION
File logging and configurable minimum log level for sentry-native/crashpad:
- https://github.com/getsentry/crashpad/pull/148
- https://github.com/getsentry/sentry-native/pull/1658

Two additions to mini_chromium's logging:

1. **`LOG_TO_FILE` destination.** Implements the previously stubbed `LOG_TO_FILE` destination and adds a simplified `base::OpenFile()` helper (after upstream Chromium's helper of the same name). Callers pass the path via `LoggingSettings::log_file_path`. The file is opened lazily for appending on the first emitted message and held by a `std::unique_ptr<FILE>` with a silent closer, so an `fclose` failure during static destruction cannot re-enter `Flush()` and deadlock on the file lock. File state (lock, path, handle, and an `enabled` flag) is grouped in a file-scope `LogFile` struct; an empty path or a failed open is handled by clearing `enabled`, so a transient open failure cannot clobber a concurrent `InitLogging()`. Concurrent LOG calls are serialized with a `base::Lock`.

2. **Configurable minimum log level.** Replaces the hardcoded `GetMinLogLevel()` with a runtime-configurable value. Adds `SetMinLogLevel()` and a `min_log_level` field on `LoggingSettings` (applied by `InitLogging`). Default remains `LOG_INFO`, so existing callers are unaffected.

`g_logging_destination` and `g_min_log_level` are `std::atomic` so reads on the LOG hot path don't need the file lock and writes from `InitLogging` / `SetMinLogLevel` don't race concurrent readers.

See also:
- https://github.com/getsentry/sentry-native/issues/1468